### PR TITLE
Support importing from a non-Expo project

### DIFF
--- a/src/Components/CheckBox.js
+++ b/src/Components/CheckBox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 const CheckBox = props => {
     let backgroundColor, color = '#0000';

--- a/src/Components/CollapsibleCard.js
+++ b/src/Components/CollapsibleCard.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 class CollapsibleCard extends Component {
   state = {

--- a/src/Components/ColorPicker.js
+++ b/src/Components/ColorPicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 const ColorPicker = props =>
   <FlatList

--- a/src/Components/IconPicker.js
+++ b/src/Components/IconPicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 const IconPicker = props => 
   <FlatList

--- a/src/Components/Tag.js
+++ b/src/Components/Tag.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 const Tag = props => 
   <TouchableOpacity


### PR DESCRIPTION
This changes all the imports for react-native-vector-icons to use a path that works with both Expo & non-Expo projects.

I've tested this in an Expo project and it's working properly for me.