### PR TITLE
Added customization via props on borderRadius and borderWidth inside the CheckBox component

### DIFF
--- a/src/Components/CheckBox.tsx
+++ b/src/Components/CheckBox.tsx
@@ -1,25 +1,29 @@
-import React from "react";
-import { TouchableOpacity } from "react-native";
-import Icon from "react-native-vector-icons/MaterialIcons";
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 export type CheckBoxProps = {
   checked?: boolean;
   color?: string;
   disabled?: boolean;
+  borderRadius?: number;
+  borderWidth?: number;
   onPress?: () => void;
 };
 
 export function CheckBox({
   checked = false,
-  color = "#000",
+  color = '#000',
   disabled = false,
+  borderRadius = 1,
+  borderWidth = 2,
   onPress = () => {},
 }: CheckBoxProps) {
   let backgroundColor,
-    checkColor = "#0000";
+    checkColor = '#0000';
   if (checked) {
     backgroundColor = color;
-    checkColor = "#fff";
+    checkColor = '#fff';
   }
   let opacity = 1;
   if (disabled) {
@@ -32,8 +36,8 @@ export function CheckBox({
       style={{
         backgroundColor,
         borderColor: color,
-        borderRadius: 1,
-        borderWidth: 2,
+        borderRadius,
+        borderWidth,
         opacity,
       }}
     >

--- a/src/Components/CheckBox.tsx
+++ b/src/Components/CheckBox.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { TouchableOpacity } from 'react-native';
-import Icon from 'react-native-vector-icons/MaterialIcons';
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import Icon from "react-native-vector-icons/MaterialIcons";
 
 export type CheckBoxProps = {
   checked?: boolean;
@@ -13,17 +13,17 @@ export type CheckBoxProps = {
 
 export function CheckBox({
   checked = false,
-  color = '#000',
+  color = "#000",
   disabled = false,
   borderRadius = 1,
   borderWidth = 2,
   onPress = () => {},
 }: CheckBoxProps) {
   let backgroundColor,
-    checkColor = '#0000';
+    checkColor = "#0000";
   if (checked) {
     backgroundColor = color;
-    checkColor = '#fff';
+    checkColor = "#fff";
   }
   let opacity = 1;
   if (disabled) {


### PR DESCRIPTION
As requested [here](https://github.com/ThakurBallary/react-native-btr-demo/issues/30), more customization options were missing and would be a nice touch to this awesome package, so I made this small change.

With this you can call the CheckBox component and pass borderRadius and borderWidth props to customize it the way you want.